### PR TITLE
fix: updated alpine & dependent openssl & squid to fix letsencrypt CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:latest
 
 LABEL maintainer="alatas@gmail.com"
 
@@ -15,8 +15,8 @@ ENV http_proxy=$all_proxy \
     https_proxy=$all_proxy
 
 RUN apk add --no-cache \
-    squid=3.5.27-r0 \
-    openssl=1.0.2p-r0 \
+    squid=6.6-r0 \
+    openssl=3.1.4-r5\
     ca-certificates && \
     update-ca-certificates
 

--- a/conf/squid.conf
+++ b/conf/squid.conf
@@ -1,3 +1,5 @@
+acl intermediate_fetching transaction_initiator certificate-fetching
+http_access allow intermediate_fetching
 #
 # Recommended minimum configuration:
 #
@@ -59,7 +61,7 @@ http_access deny all
 http_port 3128
 
 # Squid normally listens to port 4128 for ssl bump
-http_port 4128 ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=4MB cert=/etc/squid-cert/private.pem key=/etc/squid-cert/private.pem 
+http_port 4128 ssl-bump generate-host-certificates=on dynamic_cert_mem_cache_size=20MB tls-cert=/etc/squid-cert/CA.pem tls-key=/etc/squid-cert/private.pem 
 ssl_bump server-first all
 always_direct allow all
 
@@ -81,3 +83,6 @@ refresh_pattern .		30	20%	4320 reload-into-ims
 range_offset_limit 200 MB
 maximum_object_size 200 MB
 quick_abort_min -1
+sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 20MB
+sslproxy_cert_error allow all
+ssl_bump stare all

--- a/start.sh
+++ b/start.sh
@@ -42,9 +42,13 @@ create_cert() {
 
 clear_certs_db() {
 	echo "Clearing generated certificate db..."
-	rm -rfv /var/lib/ssl_db/
-	/usr/lib/squid/ssl_crtd -c -s /var/lib/ssl_db
-	"$CHOWN" -R squid.squid /var/lib/ssl_db
+	mkdir -p /var/lib/squid
+
+	rm -rf /var/lib/squid/ssl_db
+
+
+	/usr/lib/squid/security_file_certgen -c -s /var/lib/squid/ssl_db -M 20MB
+	"$CHOWN" -R squid.squid /var/lib/squid
 }
 
 run() {


### PR DESCRIPTION
I like the ease of use for this squid setup with ssl-bump, just needs to be updated to use the latest certs , particularly to replace the letsencrypt expired cert. See https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/#:~:text=DST%20Root%20CA%20X3%20will,that%20use%20Let's%20Encrypt%20certificates.

I updated the squid version and openssl since they seem to be a dependency for the latest alpine versions. There are some config and squid util changes needed to make them work.